### PR TITLE
Explicit operator type argument in with_jacobian

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,9 +6,7 @@ AutoDiffOperators.jl uses AD-backend abstractions and supports a subset of the A
 
 AD-backends are specified via subtypes of [`ADSelector`](@ref), separate backends for forward and reverse mode AD can be specified if desired. Different AD specifiers that refer to the same AD-backend can be converted into each other via [`convert_ad`](@ref).
 
-The main functions are [`with_gradient`](@ref) and [`with_jacobian`](@ref). Explicit Jacobian matrices can be obtained via [`jacobian_matrix`](@ref). The central lower-level functions are [`with_jvp`](@ref) and [`with_vjp_func`](@ref).
-
-Operators (as returned from [`with_jacobian`](@ref)) can be converted to a [LinearMaps.LinearMap](https://github.com/JuliaLinearAlgebra/LinearMaps.jl).
+The main functions are [`with_gradient`](@ref) and [`with_jacobian`](@ref). The central lower-level functions are [`with_jvp`](@ref) and [`with_vjp_func`](@ref). Jacobian operators can be implicit (e.g. a [`LinearMap`/`FunctionMap`](https://github.com/JuliaLinearAlgebra/LinearMaps.jl) or similar) or explixit (i.e. a `Matrix`).
 
 Different Julia packages require function and gradient calculation to be passed in a different fashion. AutoDiffOperators provides
 

--- a/ext/AutoDiffOperatorsEnzymeExt.jl
+++ b/ext/AutoDiffOperatorsEnzymeExt.jl
@@ -125,9 +125,11 @@ end
 
 # ToDo: Broadcast specialization of functions returned by `with_vjp_func` for multiple z-values.
 
-
-function AutoDiffOperators.with_jacobian(f, x::AbstractVector{<:Real}, ::Type{<:Matrix}, ad::EnzymeAD)
-    f(x), Enzyme.jacobian(Enzyme.Forward, f, x)
+@static if VERSION >= v"1.9"
+    # Causes crashes on (at least) Julia v1.6:
+    function AutoDiffOperators.with_jacobian(f, x::AbstractVector{<:Real}, ::Type{<:Matrix}, ad::EnzymeAD)
+        f(x), Enzyme.jacobian(Enzyme.Forward, f, x)
+    end
 end
 
 

--- a/ext/AutoDiffOperatorsEnzymeExt.jl
+++ b/ext/AutoDiffOperatorsEnzymeExt.jl
@@ -54,8 +54,8 @@ end
 
 
 function AutoDiffOperators.with_jvp(f, x::AbstractVector{<:Real}, z::AbstractVector{<:Real}, ::EnzymeAD)
-    # ToDo: Improve implementation
-    f(x), autodiff(Forward, f, DuplicatedNoNeed, Duplicated(x, z))[1]
+    f_x, J_z = autodiff(Forward, f, Duplicated, Duplicated(x, z))
+    return f_x, J_z
 end
 
 # ToDo: Broadcast specialization of `with_jvp` for multiple z-values using `Enzyme.BatchDuplicated`.

--- a/ext/AutoDiffOperatorsEnzymeExt.jl
+++ b/ext/AutoDiffOperatorsEnzymeExt.jl
@@ -49,10 +49,6 @@ function AutoDiffOperators.with_gradient!!(f, δx::AbstractVector{<:Real}, x::Ab
 end
 
 
-# ToDo: Specialize?
-# AutoDiffOperators.jacobian_matrix(f, x::AbstractVector{<:Real}, ad::EnzymeAD)
-
-
 function AutoDiffOperators.with_jvp(f, x::AbstractVector{<:Real}, z::AbstractVector{<:Real}, ::EnzymeAD)
     f_x, J_z = autodiff(Forward, f, Duplicated, Duplicated(x, z))
     return f_x, J_z
@@ -128,6 +124,11 @@ end
 
 
 # ToDo: Broadcast specialization of functions returned by `with_vjp_func` for multiple z-values.
+
+
+function AutoDiffOperators.with_jacobian(f, x::AbstractVector{<:Real}, ::Type{<:Matrix}, ad::EnzymeAD)
+    f(x), Enzyme.jacobian(Enzyme.Forward, f, x)
+end
 
 
 end # module Enzyme

--- a/ext/AutoDiffOperatorsForwardDiffExt.jl
+++ b/ext/AutoDiffOperatorsForwardDiffExt.jl
@@ -78,7 +78,9 @@ end
 
 
 # ToDo: Use AD parameters
-AutoDiffOperators.jacobian_matrix(f, x::AbstractVector{<:Real}, ad::ForwardDiffAD) = ForwardDiff.jacobian(f, x)
+function AutoDiffOperators.with_jacobian(f, x::AbstractVector{<:Real}, ::Type{<:Matrix}, ad::ForwardDiffAD)
+    f(x), ForwardDiff.jacobian(f, x)
+end
 
 
 # ToDo: Use AD parameters

--- a/ext/AutoDiffOperatorsLinearMapsExt.jl
+++ b/ext/AutoDiffOperatorsLinearMapsExt.jl
@@ -13,6 +13,18 @@ import AutoDiffOperators
 using LinearAlgebra
 
 
+function AutoDiffOperators.mulfunc_operator(
+    ::Type{Union{LinearMap,FunctionMap}},
+    ::Type{T}, sz::Dims{2}, ovp, vop,
+    ::Val{sym}, ::Val{herm}, ::Val{posdef}
+) where {T<:Real, sym, herm, posdef}
+    FunctionMap{T,false}(
+        ovp, vop, sz...;
+        isposdef=posdef, issymmetric=sym, ishermitian=herm
+    )
+end
+
+
 LinearMaps.LinearMap{T}(op::AutoDiffOperators.MatrixLikeOperator{T}) where T = LinearMaps.FunctionMap{T}(op)
 LinearMaps.LinearMap(op::AutoDiffOperators.MatrixLikeOperator{T}) where T = LinearMaps.LinearMap{T}(op)
 

--- a/ext/AutoDiffOperatorsZygoteExt.jl
+++ b/ext/AutoDiffOperatorsZygoteExt.jl
@@ -74,8 +74,8 @@ function AutoDiffOperators.with_vjp_func(f, x, ::ZygoteAD)
 end
 
 
-function AutoDiffOperators.jacobian_matrix(f, x::AbstractVector{<:Real}, ::ZygoteAD)
-    only(Zygote.jacobian(f, x))
+function AutoDiffOperators.with_jacobian(f, x::AbstractVector{<:Real}, ::Type{<:Matrix}, ad::ZygoteAD)
+    f(x), only(Zygote.jacobian(f, x))
 end
 
 

--- a/src/AutoDiffOperators.jl
+++ b/src/AutoDiffOperators.jl
@@ -7,6 +7,8 @@ Provides Julia operators that act via automatic differentiation.
 """
 module AutoDiffOperators
 
+using Base.Threads: nthreads, threadid, @threads
+
 using LinearAlgebra
 
 import ADTypes
@@ -15,6 +17,7 @@ import AbstractDifferentiation
 using AffineMaps: Mul
 using FunctionChains: fchain
 
+include("mulfunc_operator.jl")
 include("matrix_like_operator.jl")
 include("ad_selector.jl")
 include("jacobian.jl")

--- a/src/ad_selector.jl
+++ b/src/ad_selector.jl
@@ -82,9 +82,8 @@ The following functions must be specialized for subtypes of `ADSelector`:
 [`convert_ad`](@ref), [`with_jvp`](@ref), [`with_vjp_func`](@ref) and
 [`AutoDiffOperators.supports_structargs`](@ref)
 
-Default implementations are provided for [`jacobian_matrix`](@ref) and
-[`with_gradient`](@ref), but specialized implementations may often
-be more performant.
+A default implementation is provided for [`with_gradient`](@ref), but
+specialized implementations may often be more performant.
 
 Selector types that forward forward and reverse-mode ad to
 other selector types should specialize [`forward_ad_selector`](@ref)

--- a/src/matrix_like_operator.jl
+++ b/src/matrix_like_operator.jl
@@ -90,6 +90,15 @@ Base.transpose(op::MatrixLikeOperator{<:Real}) = adjoint(op)
 transpose_op_mul(op::MatrixLikeOperator{<:Real}, x::AbstractVector{<:Real}) = adjoint_op_mul(op, x)
 
 
+function mulfunc_operator(
+    ::Type{MatrixLikeOperator},
+    ::Type{T}, sz::Dims{2}, ovp, vop,
+    ::Val{sym}, ::Val{herm}, ::Val{posdef}
+) where {T<:Real, sym, herm, posdef}
+    _MulFuncOperator{T,sym,herm,posdef}(ovp, vop, Dims(sz))
+end
+
+
 """
     struct AutoDiffOperators.AdjointMatrixLikeOperator{T<:Number,sym,herm,posdef} <: MatrixLikeOperator{T,sym,herm,posdef}
 
@@ -260,7 +269,7 @@ end
 
 
 function _op_copyto_impl!(A::AbstractMatrix{<:Number}, op::MatrixLikeOperator)
-    first_j_A = firstindex(A, 1)
+    first_j_A = firstindex(A, 2)
     first_j_op = firstindex(op, 1)
     Base.Threads.@threads for j in Base.OneTo(size(op, 2))
         _get_column!(view(A, :, j-1+first_j_A), op, j-1+first_j_op)

--- a/src/mulfunc_operator.jl
+++ b/src/mulfunc_operator.jl
@@ -1,0 +1,52 @@
+# This file is a part of AutoDiffOperators.jl, licensed under the MIT License (MIT).
+
+"""
+    AutoDiffOperators.mulfunc_operator(
+        ::Type{OP},
+        ::Type{T}, sz::Dims{2}, ovp, vop,
+        ::Val{sym}, ::Val{herm}, ::Val{posdef}
+    ) where {OP, T<:Real, sym, herm, posdef}
+
+Generates a linear operator object of type `OP` that supports multiplication
+and with (adjoint) vectors based on a multiplication function `ovp` and an
+adjoint multiplication function `vop`.
+
+An operator
+`op = mulfunc_operator(OP, T, sz, ovp, vop, Val(sym), ::Val{herm}, ::Val{posdef})`
+must show show following behavior:
+
+```julia
+op isa OP
+eltype(op) == T
+size(op) == sz
+op * x_r == ovp(x_r)
+x_l' * op == vop(x_l)
+issymmetric(op) == sym
+ishermitian(op) == herm
+isposdef(op) = posdef
+```
+
+where `x_l` and `x_r` are vectors of size `sz[1]` and `sz[2]` respectively.
+"""
+function mulfunc_operator end
+
+function mulfunc_operator(
+    ::Type{Matrix},
+    ::Type{T}, sz::Dims{2}, ovp, vop,
+    ::Val{sym}, ::Val{herm}, ::Val{posdef}
+) where {T<:Real, sym, herm, posdef}
+    A = Matrix{T}(undef, sz)
+    first_j_A = firstindex(A, 2)
+    X = Matrix{T}(undef, sz[2], nthreads())
+    first_j_X = firstindex(X, 1)
+    fill!(X, zero(T))
+    @threads for j in Base.OneTo(sz[2])
+        col = view(A, :, j-1+first_j_A)
+        x = view(X, :, threadid())
+        j_x = j-1+first_j_X
+        x[j_x] = one(T)
+        col .= ovp(x)
+        x[j_x] = zero(T)
+    end
+    return A
+end

--- a/test/test_mulfunc_operator.jl
+++ b/test/test_mulfunc_operator.jl
@@ -1,0 +1,13 @@
+# This file is a part of AutoDiffOperators.jl, licensed under the MIT License (MIT).
+
+using AutoDiffOperators
+using Test
+
+using LinearAlgebra
+using AffineMaps
+
+@testset "mulfunc_operator" begin
+    A = randn(Float32, 4, 5)
+
+    @test @inferred(AutoDiffOperators.mulfunc_operator(Matrix, eltype(A), size(A), Mul(A), Mul(A'), Val(false), Val(false), Val(false))) ≈ A
+end


### PR DESCRIPTION
Changes `with_jacobian` to take operator type argument, so users should now do

```julia
with_jacobian(f, x, LinearMap, ad)
with_jacobian(f, x, MatrixLikeOperator, ad)
with_jacobian(f, x, Matrix, ad)
```

`MatrixLikeOperator` can be deprecated and removed in future releases since LinearMaps has a pretty low load time now.

CC @dkarrasch