### PR TITLE
Increase lower compat with ADTypes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,7 +25,7 @@ AutoDiffOperatorsLinearMapsExt = "LinearMaps"
 AutoDiffOperatorsZygoteExt = "Zygote"
 
 [compat]
-ADTypes = "0.1, 0.2, 1"
+ADTypes = "0.2, 1"
 AffineMaps = "0.2, 0.3"
 DifferentiationInterface = "0.5, 0.6"
 Enzyme = "0.11, 0.12, 0.13"


### PR DESCRIPTION
The current version of `AutoDiffOperators` imports `AutoFiniteDifferences` and `AutoEnzyme`.

`AutoEnzyme` was introduced in `ADTypes@0.1.1` and `AutoFiniteDifferences` was introduced in `ADTypes@0.2.0`.
Therefore, the support for `ADTypes@0.1` should be dropped.