### PR TITLE
Allow CI to fail on Julia pre

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,7 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.version == 'nightly' }}
+    continue-on-error: ${{ matrix.version == 'nightly' || matrix.version == 'pre' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Mooncake doesn't work on Julia v1.12 pre yet.